### PR TITLE
fix: ctrl+l shortkey

### DIFF
--- a/src/components/Shortcuts.svelte
+++ b/src/components/Shortcuts.svelte
@@ -3,19 +3,16 @@
 	import { getBrowserShortcut } from '$utils/shortcutsHelpers';
 	import { fade } from 'svelte/transition';
 	import ShortcutCards from './ShortcutCards.svelte';
+	import { os } from '$stores/ui';
 
-	$: chromeMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'chrome') : [];
-	$: firefoxMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'firefox') : [];
-	$: safariMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'safari') : [];
-	$: chromeWindowsShortcuts = $keys.length ? getBrowserShortcut($keys, 'windows', 'chrome') : [];
-	$: firefoxWindowsShortcuts = $keys.length ? getBrowserShortcut($keys, 'windows', 'firefox') : [];
+	$: chromeShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'chrome') : [];
+	$: firefoxShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'firefox') : [];
+	$: safariShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'safari') : [];
 
 	$: matchedShortcuts = [
-		...chromeMacShortcuts,
-		...firefoxMacShortcuts,
-		...safariMacShortcuts,
-		...chromeWindowsShortcuts,
-		...firefoxWindowsShortcuts
+		...chromeShortcuts,
+		...firefoxShortcuts,
+		...safariShortcuts,
 	].sort((a, b) => a.unmatchedKeys - b.unmatchedKeys);
 	$: numberShortcuts = matchedShortcuts.length;
 </script>

--- a/src/components/Shortcuts.svelte
+++ b/src/components/Shortcuts.svelte
@@ -3,16 +3,19 @@
 	import { getBrowserShortcut } from '$utils/shortcutsHelpers';
 	import { fade } from 'svelte/transition';
 	import ShortcutCards from './ShortcutCards.svelte';
-	import { os } from '$stores/ui';
 
-	$: chromeShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'chrome') : [];
-	$: firefoxShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'firefox') : [];
-	$: safariShortcuts = $keys.length ? getBrowserShortcut($keys, $os, 'safari') : [];
+	$: chromeMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'chrome') : [];
+	$: firefoxMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'firefox') : [];
+	$: safariMacShortcuts = $keys.length ? getBrowserShortcut($keys, 'mac', 'safari') : [];
+	$: chromeWindowsShortcuts = $keys.length ? getBrowserShortcut($keys, 'windows', 'chrome') : [];
+	$: firefoxWindowsShortcuts = $keys.length ? getBrowserShortcut($keys, 'windows', 'firefox') : [];
 
 	$: matchedShortcuts = [
-		...chromeShortcuts,
-		...firefoxShortcuts,
-		...safariShortcuts,
+		...chromeMacShortcuts,
+		...firefoxMacShortcuts,
+		...safariMacShortcuts,
+		...chromeWindowsShortcuts,
+		...firefoxWindowsShortcuts
 	].sort((a, b) => a.unmatchedKeys - b.unmatchedKeys);
 	$: numberShortcuts = matchedShortcuts.length;
 </script>

--- a/src/data/firefoxMac.json
+++ b/src/data/firefoxMac.json
@@ -389,7 +389,7 @@
 	},
 	{
 		"shortcut": [["Ctrl", "L"]],
-		"text": "Clear output"
+		"text": "Jump to the address bar"
 	},
 	{
 		"shortcut": [["Ctrl", "K"]],

--- a/src/data/firefoxWin.json
+++ b/src/data/firefoxWin.json
@@ -400,8 +400,8 @@
 		"text": "Focus on the command line"
 	},
 	{
-		"shortcut": [["Control", "Shift", "L"]],
-		"text": "Clear output"
+		"shortcut": [["Control", "L"]],
+		"text": "Jump to the address bar"
 	},
 	{
 		"shortcut": [["Home"]],


### PR DESCRIPTION
As mentioned in #3, the descriptions shown for the `Ctrl`+`L` were, as far as I know, not correct.
Additionally, I realized a bug, that the selected OS was ignored when filtering the shortkeys. 
This PR should fix both of that.